### PR TITLE
Update README.md, fix space in chat badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 *flow*
 ====
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/flow-stack/flow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/flow-stack/flow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Stack Share](http://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](http://stackshare.io/sebastianconcept/flow)
 
 A living full-stack framework for the web. 


### PR DESCRIPTION
In the url to the "gitter join chat" badge, the image name `Join Chat.svg`,
contains a space. That makes the url appear instead of the image. This replaces
the space with `%20`, so that the badge is shown correctly.